### PR TITLE
fix: enforce lot size multiples in trading bot and paper trading api

### DIFF
--- a/app/client/src/components/dashboard/active-trades.tsx
+++ b/app/client/src/components/dashboard/active-trades.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
+import { getLotSizeForSymbol } from '@/utils/tradeUtils'
 
 interface Trade {
   id: string
@@ -160,14 +161,6 @@ const statusLabel: Record<string, string> = {
   CLOSED: 'Closed',
   SL_HIT: 'SL Hit',
   TARGET_HIT: 'Target',
-}
-
-function getLotSizeForSymbol(symbol: string): number {
-  const upper = symbol.toUpperCase()
-  if (upper.includes('BANKNIFTY') || upper.includes('NIFTY BANK')) return 15
-  if (upper.includes('FINNIFTY')) return 40
-  if (upper.includes('NIFTY 50') || upper.includes('NIFTY')) return 25
-  return 1
 }
 
 function TradesTable({ trades }: { trades: Trade[] }) {

--- a/app/client/src/components/dashboard/active-trades.tsx
+++ b/app/client/src/components/dashboard/active-trades.tsx
@@ -162,6 +162,14 @@ const statusLabel: Record<string, string> = {
   TARGET_HIT: 'Target',
 }
 
+function getLotSizeForSymbol(symbol: string): number {
+  const upper = symbol.toUpperCase()
+  if (upper.includes('BANKNIFTY') || upper.includes('NIFTY BANK')) return 15
+  if (upper.includes('FINNIFTY')) return 40
+  if (upper.includes('NIFTY 50') || upper.includes('NIFTY')) return 25
+  return 1
+}
+
 function TradesTable({ trades }: { trades: Trade[] }) {
   return (
     <Table>
@@ -191,7 +199,19 @@ function TradesTable({ trades }: { trades: Trade[] }) {
               <Badge variant={typeVariant[trade.type]}>{trade.type}</Badge>
             </TableCell>
             <TableCell className="text-right font-mono text-sm">
-              {trade.qty}
+              <div>
+                <span>{trade.qty}</span>
+                {trade.type !== 'EQ' && (
+                  <span className="text-[10px] text-muted-foreground ml-1.5 font-normal">
+                    ({Math.round(trade.qty / getLotSizeForSymbol(trade.symbol))}{' '}
+                    {Math.round(trade.qty / getLotSizeForSymbol(trade.symbol)) >
+                    1
+                      ? 'lots'
+                      : 'lot'}
+                    )
+                  </span>
+                )}
+              </div>
             </TableCell>
             <TableCell className="text-right font-mono text-sm">
               ₹

--- a/app/client/src/components/dashboard/active-trades.tsx
+++ b/app/client/src/components/dashboard/active-trades.tsx
@@ -194,16 +194,18 @@ function TradesTable({ trades }: { trades: Trade[] }) {
             <TableCell className="text-right font-mono text-sm">
               <div>
                 <span>{trade.qty}</span>
-                {trade.type !== 'EQ' && (
-                  <span className="text-[10px] text-muted-foreground ml-1.5 font-normal">
-                    ({Math.round(trade.qty / getLotSizeForSymbol(trade.symbol))}{' '}
-                    {Math.round(trade.qty / getLotSizeForSymbol(trade.symbol)) >
-                    1
-                      ? 'lots'
-                      : 'lot'}
+                {(() => {
+                  const lotSize = getLotSizeForSymbol(trade.symbol)
+                  if (lotSize > 1 && trade.type !== 'EQ') {
+                    const lots = Math.round(trade.qty / lotSize)
+                    return (
+                      <span className="text-[10px] text-muted-foreground ml-1.5 font-normal">
+                        ({lots} {lots > 1 ? 'lots' : 'lot'})
+                      </span>
                     )
-                  </span>
-                )}
+                  }
+                  return null
+                })()}
               </div>
             </TableCell>
             <TableCell className="text-right font-mono text-sm">

--- a/app/client/src/hooks/useStrategyBot.ts
+++ b/app/client/src/hooks/useStrategyBot.ts
@@ -1237,7 +1237,13 @@ async function fetchMarket(
   return { candles, optionChain, v3, breadth, globalIndices, giftNifty }
 }
 
-const LOT_SIZE = 25
+function getLotSizeForSymbol(symbol: string): number {
+  const upper = symbol.toUpperCase()
+  if (upper.includes('BANKNIFTY') || upper.includes('NIFTY BANK')) return 15
+  if (upper.includes('FINNIFTY')) return 40
+  if (upper.includes('NIFTY 50') || upper.includes('NIFTY')) return 25
+  return 1
+}
 
 // ─── Hook ──────────────────────────────────────────────────────────────────────
 const INITIAL: BotStatus = {
@@ -1566,8 +1572,12 @@ export function useStrategyBot(token: string | null) {
             }
 
             const executionMode: ExecutionMode = config.executionMode
+            const lotSize =
+              optionChain.length > 0
+                ? getLotSizeForSymbol(optionChain[0].call_options.instrument_key)
+                : 25
             let qty =
-              finalSignal.positionSize === 'full' ? LOT_SIZE * 2 : LOT_SIZE
+              finalSignal.positionSize === 'full' ? lotSize * 2 : lotSize
 
             let paperBalance: number | null = null
             if (executionMode === 'paper') {
@@ -1585,9 +1595,9 @@ export function useStrategyBot(token: string | null) {
               }
 
               if (paperBalance !== null && totalReq > 0) {
-                const lotReq = totalReq * LOT_SIZE
+                const lotReq = totalReq * lotSize
                 const affordableLots = Math.floor(paperBalance / lotReq)
-                const affordableQty = affordableLots * LOT_SIZE
+                const affordableQty = affordableLots * lotSize
                 if (affordableQty <= 0) {
                   addLog(
                     mkLog(

--- a/app/client/src/hooks/useStrategyBot.ts
+++ b/app/client/src/hooks/useStrategyBot.ts
@@ -1567,9 +1567,7 @@ export function useStrategyBot(token: string | null) {
 
             const executionMode: ExecutionMode = config.executionMode
             let qty =
-              finalSignal.positionSize === 'full'
-                ? LOT_SIZE
-                : Math.floor(LOT_SIZE / 2)
+              finalSignal.positionSize === 'full' ? LOT_SIZE * 2 : LOT_SIZE
 
             let paperBalance: number | null = null
             if (executionMode === 'paper') {
@@ -1587,17 +1585,19 @@ export function useStrategyBot(token: string | null) {
               }
 
               if (paperBalance !== null && totalReq > 0) {
-                const affordableQty = Math.floor(paperBalance / totalReq)
+                const lotReq = totalReq * LOT_SIZE
+                const affordableLots = Math.floor(paperBalance / lotReq)
+                const affordableQty = affordableLots * LOT_SIZE
                 if (affordableQty <= 0) {
                   addLog(
                     mkLog(
                       'warn',
                       'paper',
-                      `Skipping paper entry: balance ₹${paperBalance.toFixed(2)} cannot afford combo margin/cost ₹${totalReq.toFixed(2)}`,
+                      `Skipping paper entry: balance ₹${paperBalance.toFixed(2)} cannot afford even 1 lot (cost ₹${lotReq.toFixed(2)})`,
                     ),
                   )
                   updateStatus({
-                    error: `Paper credit ₹${paperBalance.toFixed(2)} is below required margin/cost ₹${totalReq.toFixed(2)}`,
+                    error: `Paper credit ₹${paperBalance.toFixed(2)} is below required margin/cost per lot ₹${lotReq.toFixed(2)}`,
                   })
                   return
                 }

--- a/app/client/src/pages/live-trades.tsx
+++ b/app/client/src/pages/live-trades.tsx
@@ -666,15 +666,18 @@ function TradesTable({ rows }: { rows: TradeRow[] }) {
             <TableCell className="text-right font-mono text-sm">
               <div>
                 <span>{row.qty}</span>
-                {row.type !== 'EQ' && (
-                  <span className="text-[10px] text-muted-foreground ml-1.5 font-normal">
-                    ({Math.round(row.qty / getLotSizeForSymbol(row.symbol))}{' '}
-                    {Math.round(row.qty / getLotSizeForSymbol(row.symbol)) > 1
-                      ? 'lots'
-                      : 'lot'}
+                {(() => {
+                  const lotSize = getLotSizeForSymbol(row.symbol)
+                  if (lotSize > 1 && row.type !== 'EQ') {
+                    const lots = Math.round(row.qty / lotSize)
+                    return (
+                      <span className="text-[10px] text-muted-foreground ml-1.5 font-normal">
+                        ({lots} {lots > 1 ? 'lots' : 'lot'})
+                      </span>
                     )
-                  </span>
-                )}
+                  }
+                  return null
+                })()}
               </div>
             </TableCell>
             <TableCell className="text-right font-mono text-sm">

--- a/app/client/src/pages/live-trades.tsx
+++ b/app/client/src/pages/live-trades.tsx
@@ -159,6 +159,14 @@ function inferType(symbol: string): TradeRow['type'] {
   return 'EQ'
 }
 
+function getLotSizeForSymbol(symbol: string): number {
+  const upper = symbol.toUpperCase()
+  if (upper.includes('BANKNIFTY') || upper.includes('NIFTY BANK')) return 15
+  if (upper.includes('FINNIFTY')) return 40
+  if (upper.includes('NIFTY 50') || upper.includes('NIFTY')) return 25
+  return 1
+}
+
 const typeVariant: Record<
   TradeRow['type'],
   'default' | 'destructive' | 'secondary' | 'warning'
@@ -663,7 +671,18 @@ function TradesTable({ rows }: { rows: TradeRow[] }) {
               <Badge variant={typeVariant[row.type]}>{row.type}</Badge>
             </TableCell>
             <TableCell className="text-right font-mono text-sm">
-              {row.qty}
+              <div>
+                <span>{row.qty}</span>
+                {row.type !== 'EQ' && (
+                  <span className="text-[10px] text-muted-foreground ml-1.5 font-normal">
+                    ({Math.round(row.qty / getLotSizeForSymbol(row.symbol))}{' '}
+                    {Math.round(row.qty / getLotSizeForSymbol(row.symbol)) > 1
+                      ? 'lots'
+                      : 'lot'}
+                    )
+                  </span>
+                )}
+              </div>
             </TableCell>
             <TableCell className="text-right font-mono text-sm">
               {row.entryPrice === null ? '—' : fmtCurrency(row.entryPrice)}

--- a/app/client/src/pages/live-trades.tsx
+++ b/app/client/src/pages/live-trades.tsx
@@ -32,6 +32,7 @@ import { getAccounts } from '@/lib/accounts'
 import { fetchPaperHistory } from '@/lib/paperTrading'
 import { getStrategyConfig } from '@/lib/strategyConfig'
 import { cn, isToday, normalizeLiveStatus } from '@/lib/utils'
+import { getLotSizeForSymbol } from '@/utils/tradeUtils'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -157,14 +158,6 @@ function inferType(symbol: string): TradeRow['type'] {
   if (u.includes(' PE')) return 'PE'
   if (u.includes(' FUT')) return 'FUT'
   return 'EQ'
-}
-
-function getLotSizeForSymbol(symbol: string): number {
-  const upper = symbol.toUpperCase()
-  if (upper.includes('BANKNIFTY') || upper.includes('NIFTY BANK')) return 15
-  if (upper.includes('FINNIFTY')) return 40
-  if (upper.includes('NIFTY 50') || upper.includes('NIFTY')) return 25
-  return 1
 }
 
 const typeVariant: Record<

--- a/app/client/src/utils/tradeUtils.ts
+++ b/app/client/src/utils/tradeUtils.ts
@@ -1,0 +1,7 @@
+export function getLotSizeForSymbol(symbol: string): number {
+  const upper = symbol.toUpperCase()
+  if (upper.includes('BANKNIFTY') || upper.includes('NIFTY BANK')) return 15
+  if (upper.includes('FINNIFTY')) return 40
+  if (upper.includes('NIFTY 50') || upper.includes('NIFTY')) return 25
+  return 1
+}

--- a/app/client/worker/index.ts
+++ b/app/client/worker/index.ts
@@ -97,6 +97,14 @@ function nowIso(): string {
   return new Date().toISOString()
 }
 
+function getLotSizeForSymbol(instrumentKey: string): number {
+  const upper = instrumentKey.toUpperCase()
+  if (upper.includes('BANKNIFTY') || upper.includes('NIFTY BANK')) return 15
+  if (upper.includes('FINNIFTY')) return 40
+  if (upper.includes('NIFTY 50') || upper.includes('NIFTY')) return 25
+  return 1
+}
+
 function makeId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID()}`
 }
@@ -469,9 +477,12 @@ async function handlePaperTradeEnter(
     )
   }
 
-  if (quantity % 25 !== 0) {
+  const lotSize = getLotSizeForSymbol(body.instrumentKey)
+  if (quantity % lotSize !== 0) {
     return Response.json(
-      { error: 'Quantity must be a multiple of lot size (25)' },
+      {
+        error: `Quantity must be a multiple of lot size (${lotSize}) for ${body.instrumentKey}`,
+      },
       { status: 400 },
     )
   }

--- a/app/client/worker/index.ts
+++ b/app/client/worker/index.ts
@@ -469,6 +469,13 @@ async function handlePaperTradeEnter(
     )
   }
 
+  if (quantity % 25 !== 0) {
+    return Response.json(
+      { error: 'Quantity must be a multiple of lot size (25)' },
+      { status: 400 },
+    )
+  }
+
   try {
     const account = await ensurePaperAccount(env, userId)
     const entryValue = Number((entryPrice * quantity).toFixed(2))


### PR DESCRIPTION
Summary of Changes Committed:
Client-Side (useStrategyBot.ts): Corrected Nifty options lot-size constraints to ensure orders are placed in multiples of 25 (e.g. 50 units for Full, 25 units for Half), and prevented the budget-scaling code from reducing orders to fractional lot sizes.
Server-Side (worker/index.ts): Added a validation check to the paper trading endpoint to reject entry requests with non-multiple lot sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Live Trades and Active Trades quantity display to show estimated lot counts for non-EQ instruments.
* **Bug Fixes**
  * Improved paper-trading affordability calculations and updated related error messages.
  * Adjusted full-position sizing to use two lots.
  * Added validation to ensure paper-trade quantities are multiples of 25, returning a clear 400 error when invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->